### PR TITLE
Fix container size after loading the large image

### DIFF
--- a/jquery.elevatezoom.js
+++ b/jquery.elevatezoom.js
@@ -1145,6 +1145,11 @@ if ( typeof Object.create !== 'function' ) {
         // re-calculate values
         self.nzHeight = newImg2.height;
         self.nzWidth = newImg2.width;
+        // Fix the container's size
+        self.zoomContainer.css( {
+          height: self.$elem.height(),
+          width: self.$elem.width()
+        } );
         self.options.onImageSwapComplete( self.$elem );
 
         self.doneCallback();


### PR DESCRIPTION
When aspect ratio is varying, then loading portrait or square image leaves its zoomContainer overlapping thumbnails. This is an easy fix.
